### PR TITLE
Add capability of list all notes or list parent note

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,25 @@ The server provides the following tools for note management:
 
 - `search_notes` - Fast full-text search for finding notes by keywords
   - Requires: search query
-  - Optional: includeArchivedNotes
+  - Optional: includeArchivedNotes, includeProtectedNotes
 
 - `search_notes_advanced` - Advanced filtered search with date ranges and text search
   - Optional: created_date_start, created_date_end, modified_date_start, modified_date_end
-  - Optional: text (full-text search token), limit, includeArchivedNotes
+  - Optional: text (full-text search token), limit, includeArchivedNotes, includeProtectedNotes
+
+### Note Discovery Tools
+
+- `list_child_notes` - List direct children of a parent note (like Unix `ls` command)
+  - Optional: parentNoteId (default: "root" for top-level notes)
+  - Optional: orderBy, orderDirection, limit, includeArchivedNotes, includeProtectedNotes
+  - Use when browsing note hierarchy or listing immediate children only
+
+- `list_descendant_notes` - List ALL descendant notes recursively in database or subtree (like Unix `find` command)
+  - Optional: parentNoteId (default: "root" to search entire note tree, omit for entire database)
+  - Optional: orderBy, orderDirection, limit, includeArchivedNotes, includeProtectedNotes
+  - Use when you need complete note inventory, discovery, or bulk operations
+
+> **Function Comparison**: `list_child_notes` shows only direct children (like `ls`), while `list_descendant_notes` shows ALL descendants recursively (like `find`). Both support security defaults excluding protected and archived notes.
 
 ### Note Management Tools
 
@@ -123,12 +137,23 @@ The server provides the following tools for note management:
 
 ## Sample User Queries
 
+### Search and Discovery
 - Find my most recent 10 notes about 'n8n' since the beginning of 2020.
 - Show me notes I've edited in the last 7 days.
 - What are the 5 most recently modified notes about 'docker' from last year?
 - Find notes created in the last week.
 - Search for 'kubernetes' in notes created between January and June of this year.
 - List all notes I worked on in the last week, either created or modified.
+
+### Note Navigation and Browsing
+- "List all notes" → Uses `list_child_notes` with parentNoteId="root" to show top-level notes
+- "Show me what's in my project folder" → Uses `list_child_notes` with specific parentNoteId
+- "Browse my note hierarchy" → Uses `list_child_notes` for directory-style navigation
+
+### Complete Note Inventory
+- "Show me everything I have" → Uses `list_descendant_notes` to recursively list all notes
+- "Find all notes in my project" → Uses `list_descendant_notes` with parentNoteId for subtree search
+- "Get complete note inventory" → Uses `list_descendant_notes` for bulk operations and analysis
 
 ## Development
 

--- a/docs/future-plan.md
+++ b/docs/future-plan.md
@@ -2,7 +2,7 @@
 
 ## Immediate Next Features
 
-### 3. List Children Note Function (`list_children_notes`)
+### 1. List Children Note Function (`list_children_notes`)
 - **Function**: `list_children_notes` - Separate function for tree navigation
 - **Purpose**: Provide simple directory listing capabilities without complicating search
 - **Parameters**:

--- a/docs/future-plan.md
+++ b/docs/future-plan.md
@@ -1,8 +1,48 @@
 # TriliumNext MCP: Future Development Plans
 
+## Recently Implemented ✅
+
+### 1. List All Notes Function (`list_all_notes`) ✅ **COMPLETED**
+- **Function**: `list_all_notes` - Complete note inventory functionality
+- **Purpose**: List ALL notes in Trilium database or within a specific subtree with filtering and sorting
+- **Parameters**:
+  - `parentNoteId`: string (optional) - List notes within specific subtree, omit for entire database
+  - `orderBy`: string (optional) - Sort field (e.g., 'title', 'dateCreated', 'dateModified')
+  - `orderDirection`: 'asc' | 'desc' (optional, default: 'desc')
+  - `limit`: number (optional, default: 500) - Maximum results
+  - `includeArchivedNotes`: boolean (optional, default: false)
+  - `includeProtectedNotes`: boolean (optional, default: false)
+- **Implementation**: 
+  - Uses ETAPI search with universal match query `note.noteId != ''`
+  - Uses `ancestorNoteId` parameter when parentNoteId is provided for subtree listing
+  - Client-side filtering for protected notes
+  - Returns trimmed note objects with essential fields
+  - Provides summary with count and scope info
+- **Usage Examples**:
+  ```javascript
+  // Get all notes in entire database
+  list_all_notes()
+  
+  // Get all notes within a specific parent note
+  list_all_notes({ parentNoteId: "abc123" })
+  
+  // Get oldest notes first in a subtree
+  list_all_notes({ 
+    parentNoteId: "abc123", 
+    orderBy: "dateCreated", 
+    orderDirection: "asc" 
+  })
+  ```
+- **Benefits**: 
+  - Complete note inventory and discovery (entire database or subtree)
+  - Bulk operations and data analysis
+  - AI assistant knowledge base overview
+  - Simple alternative to complex search queries
+  - Consistent with list_children_notes parentNoteId pattern
+
 ## Immediate Next Features
 
-### 1. List Children Note Function (`list_children_notes`)
+### 1. List Children Note Function (`list_children_notes`) ✅ **COMPLETED**
 - **Function**: `list_children_notes` - Separate function for tree navigation
 - **Purpose**: Provide simple directory listing capabilities without complicating search
 - **Parameters**:

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,6 +460,9 @@ class TriliumServer {
             
             let notes = response.data.results || [];
             
+            // Filter out the parent note itself from the results
+            notes = notes.filter((note: any) => note.noteId !== parentNoteId);
+            
             // Filter out protected notes if not explicitly included
             const includeProtectedNotes = listChildParams.includeProtectedNotes === true;
             if (!includeProtectedNotes) {
@@ -520,6 +523,11 @@ class TriliumServer {
             const response = await this.axiosInstance.get(`/notes?${urlParams.toString()}`);
             
             let notes = response.data.results || [];
+            
+            // Filter out the parent note itself from the results (if parentNoteId is provided)
+            if (listDescendantNotesParams.parentNoteId && listDescendantNotesParams.parentNoteId !== "root") {
+              notes = notes.filter((note: any) => note.noteId !== listDescendantNotesParams.parentNoteId);
+            }
             
             // Filter out protected notes if not explicitly included
             const includeProtectedNotes = listDescendantNotesParams.includeProtectedNotes === true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,53 +227,14 @@ class TriliumServer {
           },
         });
         tools.push({
-          name: "list_child_notes",
-          description: "List direct child notes of a parent note (like Unix 'ls' command). Use when user wants to browse/navigate note hierarchy or list top-level notes. Use parentNoteId='root' when user asks to 'list all notes' to show top-level notes.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              parentNoteId: {
-                type: "string",
-                description: "ID of the parent note to list children from. Use 'root' for top-level notes when user asks to 'list all notes' at root level.",
-                default: "root"
-              },
-              orderBy: {
-                type: "string",
-                description: "Sort order for results (e.g., 'title', 'dateCreated', 'dateModified')",
-              },
-              orderDirection: {
-                type: "string",
-                enum: ["asc", "desc"],
-                description: "Sort direction - ascending or descending",
-                default: "asc"
-              },
-              limit: {
-                type: "number",
-                description: "Maximum number of children to return",
-              },
-              includeArchivedNotes: {
-                type: "boolean",
-                description: "Include archived notes in results",
-                default: false
-              },
-              includeProtectedNotes: {
-                type: "boolean",
-                description: "Include protected notes in results",
-                default: false
-              },
-            },
-            required: [],
-          },
-        });
-        tools.push({
           name: "list_descendant_notes",
-          description: "List ALL descendant notes recursively in database or subtree (like Unix 'find' command). Use when user wants complete note inventory, discovery, or bulk operations. When user asks to 'list all notes' and wants to see everything, use this with parentNoteId='root' or omit parentNoteId entirely.",
+          description: "List ALL descendant notes recursively in database or subtree (like Unix 'find' command). PREFERRED for 'list all notes' requests - provides complete note inventory. Use when user wants to see everything, discovery, or bulk operations, especially for 'list all notes' or 'show me everything at my note' requests",
           inputSchema: {
             type: "object",
             properties: {
               parentNoteId: {
                 type: "string",
-                description: "Optional parent note ID to search within specific subtree. Use 'root' to search entire note tree, or omit to search entire database. When user asks to 'list all notes', use 'root' or omit this parameter.",
+                description: "Optional parent note ID to search within specific subtree. Use 'root' to search entire note tree, or omit to search entire database. RECOMMENDED: Use 'root' or omit this parameter when user asks to 'list all notes'.",
                 default: "root"
               },
               orderBy: {
@@ -303,6 +264,45 @@ class TriliumServer {
                 default: false
               },
             },
+          },
+        });
+        tools.push({
+          name: "list_child_notes",
+          description: "List direct child notes of a parent note (like Unix 'ls' command). Use for browsing/navigating note hierarchy or when user specifically wants only direct children.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              parentNoteId: {
+                type: "string",
+                description: "ID of the parent note to list children from. Use 'root' for top-level notes. For 'list all notes' requests, consider using list_descendant_notes instead.",
+                default: "root"
+              },
+              orderBy: {
+                type: "string",
+                description: "Sort order for results (e.g., 'title', 'dateCreated', 'dateModified')",
+              },
+              orderDirection: {
+                type: "string",
+                enum: ["asc", "desc"],
+                description: "Sort direction - ascending or descending",
+                default: "asc"
+              },
+              limit: {
+                type: "number",
+                description: "Maximum number of children to return",
+              },
+              includeArchivedNotes: {
+                type: "boolean",
+                description: "Include archived notes in results",
+                default: false
+              },
+              includeProtectedNotes: {
+                type: "boolean",
+                description: "Include protected notes in results",
+                default: false
+              },
+            },
+            required: [],
           },
         });
       }

--- a/src/modules/contentProcessor.ts
+++ b/src/modules/contentProcessor.ts
@@ -1,0 +1,25 @@
+import { marked } from "marked";
+
+/**
+ * Detects if content is likely Markdown based on common indicators
+ */
+export function isLikelyMarkdown(content: string): boolean {
+  const markdownIndicators = ["#", "*", "-", "`", "[", "]", "(", ")", "_", ">"];
+  return markdownIndicators.some(indicator => content.includes(indicator));
+}
+
+/**
+ * Processes content and converts Markdown to HTML if detected
+ */
+export async function processContent(content: string): Promise<string> {
+  if (!isLikelyMarkdown(content)) {
+    return content;
+  }
+
+  try {
+    return await marked.parse(content);
+  } catch (e) {
+    console.error("Markdown parsing failed, using original content:", e);
+    return content;
+  }
+}

--- a/src/modules/listChildHelper.ts
+++ b/src/modules/listChildHelper.ts
@@ -1,0 +1,61 @@
+interface ListChildParams {
+  parentNoteId: string;
+  orderBy?: string;
+  orderDirection?: string;
+  limit?: number;
+  includeArchivedNotes?: boolean;
+  includeProtectedNotes?: boolean;
+}
+
+export function buildListChildQuery(params: ListChildParams): URLSearchParams {
+  // Verbose logging
+  const isVerbose = process.env.VERBOSE === "true";
+  if (isVerbose) {
+    console.error(`[VERBOSE] buildListChildQuery input:`, JSON.stringify(params, null, 2));
+  }
+
+  // Build URL parameters for ETAPI search
+  const urlParams = new URLSearchParams();
+  
+  // Build search query for direct children using Trilium search DSL
+  let searchQuery: string;
+  
+  if (params.parentNoteId === "root") {
+    // For root, find notes that have root as direct parent
+    // This means notes where one of their parents is root (note.parents.noteId = 'root')
+    searchQuery = "note.parents.noteId = 'root'";
+  } else {
+    // For specific parent, find notes that have this parent as direct parent
+    searchQuery = `note.parents.noteId = '${params.parentNoteId}'`;
+  }
+  
+  urlParams.append("search", searchQuery);
+  
+  // Use fastSearch=false for better metadata
+  urlParams.append("fastSearch", "false");
+  
+  if (params.orderBy) {
+    urlParams.append("orderBy", params.orderBy);
+    
+    // Add orderDirection if provided
+    if (params.orderDirection) {
+      urlParams.append("orderDirection", params.orderDirection);
+    }
+  }
+  
+  if (params.limit) {
+    urlParams.append("limit", params.limit.toString());
+  }
+  
+  if (typeof params.includeArchivedNotes === "boolean") {
+    urlParams.append("includeArchivedNotes", params.includeArchivedNotes.toString());
+  }
+  
+  // Note: includeProtectedNotes is handled by client-side filtering since ETAPI doesn't have this parameter
+
+  if (isVerbose) {
+    console.error(`[VERBOSE] buildListChildQuery output - urlParams: "${urlParams.toString()}"`);
+  }
+
+  return urlParams;
+}

--- a/src/modules/listChildrenHelper.ts
+++ b/src/modules/listChildrenHelper.ts
@@ -1,0 +1,55 @@
+interface ListChildrenParams {
+  parentNoteId: string;
+  orderBy?: string;
+  orderDirection?: string;
+  limit?: number;
+  includeArchivedNotes?: boolean;
+}
+
+export function buildListChildrenQuery(params: ListChildrenParams): URLSearchParams {
+  // Verbose logging
+  const isVerbose = process.env.VERBOSE === "true";
+  if (isVerbose) {
+    console.error(`[VERBOSE] buildListChildrenQuery input:`, JSON.stringify(params, null, 2));
+  }
+
+  // Build URL parameters for ETAPI search
+  const urlParams = new URLSearchParams();
+  
+  // Use a search query that matches all notes
+  // Since we need a non-empty search, we use a condition that all notes should satisfy
+  // Every note has a noteId, so we search for notes where noteId is not empty
+  urlParams.append("search", "note.noteId != ''");
+  
+  // Use ancestorNoteId and ancestorDepth for listing children
+  urlParams.append("ancestorNoteId", params.parentNoteId);
+  
+  // Use ancestorDepth=eq1 for direct children only
+  urlParams.append("ancestorDepth", "eq1");
+  
+  // Use fastSearch=false for better metadata
+  urlParams.append("fastSearch", "false");
+  
+  if (params.orderBy) {
+    urlParams.append("orderBy", params.orderBy);
+    
+    // Add orderDirection if provided
+    if (params.orderDirection) {
+      urlParams.append("orderDirection", params.orderDirection);
+    }
+  }
+  
+  if (params.limit) {
+    urlParams.append("limit", params.limit.toString());
+  }
+  
+  if (typeof params.includeArchivedNotes === "boolean") {
+    urlParams.append("includeArchivedNotes", params.includeArchivedNotes.toString());
+  }
+
+  if (isVerbose) {
+    console.error(`[VERBOSE] buildListChildrenQuery output - urlParams: "${urlParams.toString()}"`);
+  }
+
+  return urlParams;
+}

--- a/src/modules/listDescendantNotesHelper.ts
+++ b/src/modules/listDescendantNotesHelper.ts
@@ -17,14 +17,25 @@ export function buildListDescendantNotesQuery(params: ListDescendantNotesParams)
   // Build URL parameters for ETAPI search
   const urlParams = new URLSearchParams();
   
-  // Use a search query that matches all notes
-  // Every note has a noteId, so we search for notes where noteId is not empty
-  urlParams.append("search", "note.noteId != ''");
+  // Build search query for ALL descendants using Trilium search DSL
+  let searchQuery: string;
   
-  // If parentNoteId is provided, search within that subtree
   if (params.parentNoteId) {
-    urlParams.append("ancestorNoteId", params.parentNoteId);
+    if (params.parentNoteId === "root") {
+      // For root, find all notes that have root as an ancestor (all notes in the tree)
+      // This includes direct children and all their descendants
+      searchQuery = "note.ancestors.noteId = 'root'";
+    } else {
+      // For specific parent, find all notes that have this parent as an ancestor
+      // This includes direct children and all their descendants recursively
+      searchQuery = `note.ancestors.noteId = '${params.parentNoteId}'`;
+    }
+  } else {
+    // If no parentNoteId, search all notes in the database
+    searchQuery = "note.noteId != ''";
   }
+  
+  urlParams.append("search", searchQuery);
   
   // Use fastSearch=false for better metadata
   urlParams.append("fastSearch", "false");

--- a/src/modules/listDescendantNotesHelper.ts
+++ b/src/modules/listDescendantNotesHelper.ts
@@ -1,31 +1,30 @@
-interface ListChildrenParams {
-  parentNoteId: string;
+interface ListDescendantNotesParams {
+  parentNoteId?: string;
   orderBy?: string;
   orderDirection?: string;
   limit?: number;
   includeArchivedNotes?: boolean;
+  includeProtectedNotes?: boolean;
 }
 
-export function buildListChildrenQuery(params: ListChildrenParams): URLSearchParams {
+export function buildListDescendantNotesQuery(params: ListDescendantNotesParams): URLSearchParams {
   // Verbose logging
   const isVerbose = process.env.VERBOSE === "true";
   if (isVerbose) {
-    console.error(`[VERBOSE] buildListChildrenQuery input:`, JSON.stringify(params, null, 2));
+    console.error(`[VERBOSE] buildListDescendantNotesQuery input:`, JSON.stringify(params, null, 2));
   }
 
   // Build URL parameters for ETAPI search
   const urlParams = new URLSearchParams();
   
   // Use a search query that matches all notes
-  // Since we need a non-empty search, we use a condition that all notes should satisfy
   // Every note has a noteId, so we search for notes where noteId is not empty
   urlParams.append("search", "note.noteId != ''");
   
-  // Use ancestorNoteId and ancestorDepth for listing children
-  urlParams.append("ancestorNoteId", params.parentNoteId);
-  
-  // Use ancestorDepth=eq1 for direct children only
-  urlParams.append("ancestorDepth", "eq1");
+  // If parentNoteId is provided, search within that subtree
+  if (params.parentNoteId) {
+    urlParams.append("ancestorNoteId", params.parentNoteId);
+  }
   
   // Use fastSearch=false for better metadata
   urlParams.append("fastSearch", "false");
@@ -46,9 +45,11 @@ export function buildListChildrenQuery(params: ListChildrenParams): URLSearchPar
   if (typeof params.includeArchivedNotes === "boolean") {
     urlParams.append("includeArchivedNotes", params.includeArchivedNotes.toString());
   }
+  
+  // Note: includeProtectedNotes is handled by client-side filtering
 
   if (isVerbose) {
-    console.error(`[VERBOSE] buildListChildrenQuery output - urlParams: "${urlParams.toString()}"`);
+    console.error(`[VERBOSE] buildListDescendantNotesQuery output - urlParams: "${urlParams.toString()}"`);
   }
 
   return urlParams;

--- a/src/modules/noteFormatter.ts
+++ b/src/modules/noteFormatter.ts
@@ -1,0 +1,79 @@
+/**
+ * Interface for trimmed note results
+ */
+export interface TrimmedNote {
+  noteId: string;
+  title: string;
+  type: string;
+  mime: string;
+  isProtected: boolean;
+  dateCreated: string;
+  dateModified: string;
+  utcDateCreated: string;
+  utcDateModified: string;
+}
+
+/**
+ * Trims note objects to essential fields for search results
+ */
+export function trimNoteResults(notes: any[]): TrimmedNote[] {
+  return notes.map(note => ({
+    noteId: note.noteId,
+    title: note.title,
+    type: note.type,
+    mime: note.mime,
+    isProtected: note.isProtected,
+    dateCreated: note.dateCreated,
+    dateModified: note.dateModified,
+    utcDateCreated: note.utcDateCreated,
+    utcDateModified: note.utcDateModified
+  }));
+}
+
+/**
+ * Formats a date for ls-like output (e.g., "2024-08-19 14:30")
+ */
+export function formatDateForListing(dateStr: string | undefined): string {
+  if (!dateStr || dateStr === "unknown") {
+    return "unknown";
+  }
+
+  try {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) {
+      return "invalid-date";
+    }
+    return date.toISOString().slice(0, 16).replace('T', ' ');
+  } catch (e) {
+    return "invalid-date";
+  }
+}
+
+/**
+ * Gets type indicator for ls-F style output
+ */
+export function getTypeIndicator(type: string): string {
+  switch (type) {
+    case 'book': return '/';
+    case 'code': return '*';
+    case 'search': return '?';
+    default: return '';
+  }
+}
+
+/**
+ * Formats notes for list_children_notes output in ls-like format
+ */
+export function formatNotesForListing(notes: any[]): string[] {
+  return notes.map((note: any) => {
+    const title = note.title || "Untitled";
+    const noteId = note.noteId || "unknown";
+    const type = note.type || "unknown";
+    
+    const dateCreated = note.dateCreated || note.utcDateCreated || "unknown";
+    const formattedDate = formatDateForListing(dateCreated);
+    const typeIndicator = getTypeIndicator(type);
+    
+    return `${formattedDate}  ${title}${typeIndicator} (${noteId})`;
+  });
+}

--- a/src/modules/responseUtils.ts
+++ b/src/modules/responseUtils.ts
@@ -17,14 +17,14 @@ export function createSearchDebugInfo(query: string, inputParams: any): string {
 }
 
 /**
- * Creates debug information for list children operations
+ * Creates debug information for list child operations
  */
-export function createListChildrenDebugInfo(parentNoteId: string, urlParams: URLSearchParams, resultCount: number): string {
+export function createListChildDebugInfo(parentNoteId: string, urlParams: URLSearchParams, resultCount: number): string {
   if (!isVerboseMode()) {
     return "";
   }
   
-  return `--- List Children Debug ---\nParent Note ID: ${parentNoteId}\nURL Params: ${urlParams.toString()}\nRaw Result Count: ${resultCount}\n--- End Debug ---\n\n`;
+  return `--- List Child Debug ---\nParent Note ID: ${parentNoteId}\nURL Params: ${urlParams.toString()}\nRaw Result Count: ${resultCount}\n--- End Debug ---\n\n`;
 }
 
 /**

--- a/src/modules/responseUtils.ts
+++ b/src/modules/responseUtils.ts
@@ -1,0 +1,35 @@
+/**
+ * Checks if verbose logging is enabled via environment variable
+ */
+export function isVerboseMode(): boolean {
+  return process.env.VERBOSE === "true";
+}
+
+/**
+ * Creates debug information for search queries
+ */
+export function createSearchDebugInfo(query: string, inputParams: any): string {
+  if (!isVerboseMode()) {
+    return "";
+  }
+  
+  return `\n--- Query Debug ---\nBuilt Query: ${query}\nInput Params: ${JSON.stringify(inputParams, null, 2)}\n--- End Debug ---\n\n`;
+}
+
+/**
+ * Creates debug information for list children operations
+ */
+export function createListChildrenDebugInfo(parentNoteId: string, urlParams: URLSearchParams, resultCount: number): string {
+  if (!isVerboseMode()) {
+    return "";
+  }
+  
+  return `--- List Children Debug ---\nParent Note ID: ${parentNoteId}\nURL Params: ${urlParams.toString()}\nRaw Result Count: ${resultCount}\n--- End Debug ---\n\n`;
+}
+
+/**
+ * Creates a summary line for list operations
+ */
+export function createListSummary(count: number): string {
+  return `\nTotal: ${count} note${count !== 1 ? 's' : ''}`;
+}


### PR DESCRIPTION
- Add `list_child_note` - List direct children of a parent note (like Unix `ls` command)
- Add `list_descendant_note` - List ALL descendant notes recursively in database or subtree (like Unix `find` command)

These operations are performed via Trilium Search DSL: https://triliumnext.github.io/Docs/Wiki/search.html