### PR TITLE
Add get_children and move_note tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "triliumnext-mcp",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "A model context protocol server for TriliumNext Notes",
   "type": "module",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,9 @@ import {
   handleUpdateNoteRequest,
   handleDeleteNoteRequest,
   handleGetNoteRequest,
-  handleSearchReplaceNoteRequest
+  handleSearchReplaceNoteRequest,
+  handleGetChildrenRequest,
+  handleMoveNoteRequest
 } from "./modules/noteHandler.js";
 import {
   handleSearchNotesRequest
@@ -44,7 +46,7 @@ class TriliumServer {
     this.server = new Server(
       {
         name: "triliumnext-mcp",
-        version: "0.3.13",
+        version: "0.3.17",
       },
       {
         capabilities: {
@@ -104,6 +106,12 @@ class TriliumServer {
 
           case "search_and_replace_note":
             return await handleSearchReplaceNoteRequest(request.params.arguments, this.axiosInstance, this);
+
+          case "get_children":
+            return await handleGetChildrenRequest(request.params.arguments, this.axiosInstance, this);
+
+          case "move_note":
+            return await handleMoveNoteRequest(request.params.arguments, this.axiosInstance, this);
 
           // Search and listing operations
           case "search_notes":

--- a/src/modules/noteHandler.ts
+++ b/src/modules/noteHandler.ts
@@ -11,7 +11,11 @@ import {
   handleUpdateNote,
   handleDeleteNote,
   handleGetNote,
-  handleSearchReplaceNote
+  handleSearchReplaceNote,
+  handleGetChildren,
+  GetChildrenOperation,
+  handleMoveNote,
+  MoveNoteOperation
 } from "./noteManager.js";
 
 /**
@@ -300,6 +304,70 @@ export async function handleGetNoteRequest(
     if (error instanceof McpError) {
       throw error;
     }
+    throw new McpError(ErrorCode.InvalidParams, error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Handle get_children tool requests
+ */
+export async function handleGetChildrenRequest(
+  args: any,
+  axiosInstance: any,
+  permissionChecker: PermissionChecker
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  if (!permissionChecker.hasPermission("READ")) {
+    throw new McpError(ErrorCode.InvalidRequest, "Permission denied: Not authorized to get note children.");
+  }
+
+  if (!args.noteId) {
+    throw new McpError(ErrorCode.InvalidParams, "Missing required parameter 'noteId'.");
+  }
+
+  try {
+    const operation: GetChildrenOperation = { noteId: args.noteId };
+    const result = await handleGetChildren(operation, axiosInstance);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+    };
+  } catch (error) {
+    if (error instanceof McpError) throw error;
+    throw new McpError(ErrorCode.InvalidParams, error instanceof Error ? error.message : String(error));
+  }
+}
+
+/**
+ * Handle move_note tool requests
+ */
+export async function handleMoveNoteRequest(
+  args: any,
+  axiosInstance: any,
+  permissionChecker: PermissionChecker
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  if (!permissionChecker.hasPermission("WRITE")) {
+    throw new McpError(ErrorCode.InvalidRequest, "Permission denied: Not authorized to move notes.");
+  }
+
+  if (!args.noteId) {
+    throw new McpError(ErrorCode.InvalidParams, "Missing required parameter 'noteId'.");
+  }
+
+  if (!args.newParentNoteId) {
+    throw new McpError(ErrorCode.InvalidParams, "Missing required parameter 'newParentNoteId'.");
+  }
+
+  try {
+    const operation: MoveNoteOperation = {
+      noteId: args.noteId,
+      newParentNoteId: args.newParentNoteId,
+      branchId: args.branchId
+    };
+    const result = await handleMoveNote(operation, axiosInstance);
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }]
+    };
+  } catch (error) {
+    if (error instanceof McpError) throw error;
     throw new McpError(ErrorCode.InvalidParams, error instanceof Error ? error.message : String(error));
   }
 }

--- a/src/modules/noteManager.ts
+++ b/src/modules/noteManager.ts
@@ -861,6 +861,209 @@ export async function handleDeleteNote(
   };
 }
 
+// ─── get_children ────────────────────────────────────────────────────────────
+
+export interface GetChildrenOperation {
+  noteId: string;
+}
+
+export interface ChildNoteSummary {
+  noteId: string;
+  title: string;
+  type: string;
+  mime: string;
+  dateModified: string;
+}
+
+export interface GetChildrenResponse {
+  parentNoteId: string;
+  childCount: number;
+  children: ChildNoteSummary[];
+}
+
+/**
+ * Handle get_children operation – retrieve direct children of a note
+ */
+export async function handleGetChildren(
+  args: GetChildrenOperation,
+  axiosInstance: any
+): Promise<GetChildrenResponse> {
+  const { noteId } = args;
+
+  if (!noteId) {
+    throw new Error("noteId is required for get_children operation.");
+  }
+
+  logVerboseApi("GET", `/notes/${noteId}`);
+  const parentNote = await axiosInstance.get(`/notes/${noteId}`);
+  const childNoteIds: string[] = parentNote.data.childNoteIds || [];
+
+  if (childNoteIds.length === 0) {
+    return { parentNoteId: noteId, childCount: 0, children: [] };
+  }
+
+  logVerbose("handleGetChildren", `Fetching ${childNoteIds.length} children for ${noteId}`);
+
+  const results = await Promise.allSettled(
+    childNoteIds.map((childId: string) => {
+      logVerboseApi("GET", `/notes/${childId}`);
+      return axiosInstance.get(`/notes/${childId}`);
+    })
+  );
+
+  const children: ChildNoteSummary[] = [];
+  for (const result of results) {
+    if (result.status === 'fulfilled') {
+      const note = result.value.data;
+      children.push({
+        noteId: note.noteId,
+        title: note.title,
+        type: note.type,
+        mime: note.mime || '',
+        dateModified: note.dateModified
+      });
+    } else {
+      logVerboseError("handleGetChildren", result.reason);
+    }
+  }
+
+  return { parentNoteId: noteId, childCount: children.length, children };
+}
+
+// ─── move_note ────────────────────────────────────────────────────────────────
+
+export interface MoveNoteOperation {
+  noteId: string;
+  newParentNoteId: string;
+  branchId?: string;
+}
+
+export interface BranchInfo {
+  branchId: string;
+  parentNoteId: string;
+  notePosition?: number;
+}
+
+export interface MoveNoteResponse {
+  noteId: string;
+  oldParentNoteId: string;
+  newParentNoteId: string;
+  newBranchId: string;
+  message: string;
+}
+
+export interface MoveNoteAmbiguousResponse {
+  noteId: string;
+  message: string;
+  requiresBranchId: boolean;
+  branches: BranchInfo[];
+}
+
+export type MoveNoteResult = MoveNoteResponse | MoveNoteAmbiguousResponse;
+
+/**
+ * Handle move_note operation – move a note to a new parent location.
+ * Uses DELETE + POST branch pattern because PATCH /branches cannot change parentNoteId.
+ */
+export async function handleMoveNote(
+  args: MoveNoteOperation,
+  axiosInstance: any
+): Promise<MoveNoteResult> {
+  const { noteId, newParentNoteId, branchId: providedBranchId } = args;
+
+  if (!noteId || !newParentNoteId) {
+    throw new Error("noteId and newParentNoteId are required for move_note operation.");
+  }
+
+  logVerboseApi("GET", `/notes/${noteId}`);
+  const noteResponse = await axiosInstance.get(`/notes/${noteId}`);
+  const parentBranchIds: string[] = noteResponse.data.parentBranchIds || [];
+
+  if (parentBranchIds.length === 0) {
+    throw new Error(`Note ${noteId} has no parent branches and cannot be moved.`);
+  }
+
+  let targetBranchId: string;
+
+  if (parentBranchIds.length === 1) {
+    targetBranchId = parentBranchIds[0];
+  } else if (providedBranchId) {
+    if (!parentBranchIds.includes(providedBranchId)) {
+      throw new Error(
+        `Branch ${providedBranchId} does not belong to note ${noteId}. ` +
+        `Valid branches: ${parentBranchIds.join(', ')}`
+      );
+    }
+    targetBranchId = providedBranchId;
+  } else {
+    // Multiple branches, no branchId provided – ask user to choose
+    const branchDetails = await Promise.allSettled(
+      parentBranchIds.map((bid: string) => {
+        logVerboseApi("GET", `/branches/${bid}`);
+        return axiosInstance.get(`/branches/${bid}`);
+      })
+    );
+    const branches: BranchInfo[] = branchDetails
+      .filter((r): r is PromiseFulfilledResult<any> => r.status === 'fulfilled')
+      .map(r => ({
+        branchId: r.value.data.branchId,
+        parentNoteId: r.value.data.parentNoteId,
+        notePosition: r.value.data.notePosition
+      }));
+
+    return {
+      noteId,
+      message:
+        `Note ${noteId} exists in ${parentBranchIds.length} locations. ` +
+        `Specify 'branchId' to indicate which parent link to move.`,
+      requiresBranchId: true,
+      branches
+    };
+  }
+
+  // Get current branch to record old parent
+  logVerboseApi("GET", `/branches/${targetBranchId}`);
+  const branchResponse = await axiosInstance.get(`/branches/${targetBranchId}`);
+  const oldParentNoteId: string = branchResponse.data.parentNoteId;
+
+  // No-op check
+  if (oldParentNoteId === newParentNoteId) {
+    return {
+      noteId,
+      oldParentNoteId,
+      newParentNoteId,
+      newBranchId: targetBranchId,
+      message: `Note ${noteId} is already a child of ${newParentNoteId}. No move performed.`
+    };
+  }
+
+  // POST new branch first (note keeps old branch during transition, so it cannot be auto-deleted)
+  const newBranchData = { noteId, parentNoteId: newParentNoteId };
+  logVerboseApi("POST", `/branches`, newBranchData);
+  const newBranchResponse = await axiosInstance.post(`/branches`, newBranchData);
+  const newBranchId: string = newBranchResponse.data.branchId;
+
+  // Delete old branch (note now has new branch, so it is safe to remove the old one)
+  logVerboseApi("DELETE", `/branches/${targetBranchId}`);
+  try {
+    await axiosInstance.delete(`/branches/${targetBranchId}`);
+  } catch (deleteError) {
+    // New branch already created; log warning but return partial success
+    logVerboseError("handleMoveNote", deleteError);
+    logVerbose("handleMoveNote", `Note ${noteId} cloned to ${newParentNoteId} but old branch ${targetBranchId} could not be removed`);
+  }
+
+  return {
+    noteId,
+    oldParentNoteId,
+    newParentNoteId,
+    newBranchId,
+    message: `Note ${noteId} moved from ${oldParentNoteId} to ${newParentNoteId} (branch: ${newBranchId})`
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * Handle get note operation
  */

--- a/src/modules/noteManager.ts
+++ b/src/modules/noteManager.ts
@@ -877,7 +877,9 @@ export interface ChildNoteSummary {
 
 export interface GetChildrenResponse {
   parentNoteId: string;
-  childCount: number;
+  totalChildCount: number;
+  fetchedCount: number;
+  failedCount: number;
   children: ChildNoteSummary[];
 }
 
@@ -899,7 +901,7 @@ export async function handleGetChildren(
   const childNoteIds: string[] = parentNote.data.childNoteIds || [];
 
   if (childNoteIds.length === 0) {
-    return { parentNoteId: noteId, childCount: 0, children: [] };
+    return { parentNoteId: noteId, totalChildCount: 0, fetchedCount: 0, failedCount: 0, children: [] };
   }
 
   logVerbose("handleGetChildren", `Fetching ${childNoteIds.length} children for ${noteId}`);
@@ -927,7 +929,13 @@ export async function handleGetChildren(
     }
   }
 
-  return { parentNoteId: noteId, childCount: children.length, children };
+  return {
+    parentNoteId: noteId,
+    totalChildCount: childNoteIds.length,
+    fetchedCount: children.length,
+    failedCount: childNoteIds.length - children.length,
+    children
+  };
 }
 
 // ─── move_note ────────────────────────────────────────────────────────────────
@@ -1048,9 +1056,24 @@ export async function handleMoveNote(
   try {
     await axiosInstance.delete(`/branches/${targetBranchId}`);
   } catch (deleteError) {
-    // New branch already created; log warning but return partial success
     logVerboseError("handleMoveNote", deleteError);
-    logVerbose("handleMoveNote", `Note ${noteId} cloned to ${newParentNoteId} but old branch ${targetBranchId} could not be removed`);
+    logVerbose("handleMoveNote", `Failed to delete old branch ${targetBranchId}; attempting rollback of new branch ${newBranchId}`);
+    // Rollback: remove the newly-created branch so the note is not left in both locations
+    try {
+      logVerboseApi("DELETE", `/branches/${newBranchId}`);
+      await axiosInstance.delete(`/branches/${newBranchId}`);
+      logVerbose("handleMoveNote", `Rollback successful: removed new branch ${newBranchId}`);
+    } catch (rollbackError) {
+      logVerboseError("handleMoveNote", rollbackError);
+      throw new Error(
+        `Move failed and rollback failed: note ${noteId} now exists in both ${oldParentNoteId} and ${newParentNoteId}. ` +
+        `Manually delete one of the branches (old: ${targetBranchId}, new: ${newBranchId}).`
+      );
+    }
+    throw new Error(
+      `Move failed: could not delete old branch ${targetBranchId} from ${oldParentNoteId}. ` +
+      `Rollback successful — note ${noteId} remains at ${oldParentNoteId}.`
+    );
   }
 
   return {

--- a/src/modules/toolDefinitions.ts
+++ b/src/modules/toolDefinitions.ts
@@ -139,6 +139,28 @@ export function createWriteTools(): any[] {
       },
     },
     {
+      name: "move_note",
+      description: "Move a note to a new parent location in the note tree. IMPORTANT: In TriliumNext a note can exist in multiple locations (branches). If the note has only one parent it moves directly. If it has multiple parents you must specify 'branchId' to indicate which parent link to move. WORKFLOW: Call move_note without branchId first — if the note has multiple parents you will receive a list of branches to choose from, then call again with the specific branchId.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          noteId: {
+            type: "string",
+            description: "ID of the note to move"
+          },
+          newParentNoteId: {
+            type: "string",
+            description: "ID of the destination parent note"
+          },
+          branchId: {
+            type: "string",
+            description: "Optional: the specific branch ID to move. Required only when the note exists in multiple parent locations. If omitted and the note has multiple parents, the tool returns a list of available branches for you to choose from."
+          }
+        },
+        required: ["noteId", "newParentNoteId"]
+      }
+    },
+    {
       name: "search_and_replace_note",
       description: "Search and replace content within a single note. When someone wants to replace text in a note, first call get_note to get the current content and hash, then use this function to make the changes. This ensures you're working with the latest version of their note.",
       inputSchema: {
@@ -189,6 +211,20 @@ export function createReadTools(): any[] {
   const searchProperties = createSearchProperties();
 
   return [
+    {
+      name: "get_children",
+      description: "Retrieve all direct child notes of a given note. Returns an array of child note summaries including noteId, title, type, mime, and dateModified. Use this to explore the note hierarchy or list the contents of a folder/book note.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          noteId: {
+            type: "string",
+            description: "ID of the parent note whose children to retrieve"
+          }
+        },
+        required: ["noteId"]
+      }
+    },
     {
       name: "get_note",
       description: "Get a note and its content by ID. Perfect for when someone wants to see what's in a note, extract specific information, or prepare for search and replace operations. Getting the full content lets you see the context and create better regex patterns for extraction or replacement. ⚠️ SMART CONTENT INCLUSION: For file/image notes, binary content is automatically excluded by default for performance. Use includeBinaryContent: true to explicitly retrieve binary data when needed.",


### PR DESCRIPTION
## Summary

- `get_children` (READ): retrieves direct child notes of a given note, returning title, type, mime, and dateModified for each child
- `move_note` (WRITE): relocates a note to a new parent by manipulating branches; prompts for `branchId` when a note has multiple parents

## Fixes from code review

- **`get_children`**: replaced misleading `childCount` with `totalChildCount` / `fetchedCount` / `failedCount` so callers can detect partial failures when some child fetches fail
- **`move_note`**: on delete-old-branch failure, now attempts rollback of the newly-created branch and throws with a clear error rather than returning silent success; if rollback also fails, error includes manual recovery instructions

## Test plan

- [ ] `get_children` on a note with children returns correct counts and summaries
- [ ] `get_children` on a note with no children returns empty list with zero counts
- [ ] `move_note` with a single-parent note moves it correctly
- [ ] `move_note` with a multi-parent note returns ambiguous response requesting `branchId`
- [ ] `move_note` with explicit `branchId` moves the correct branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool to retrieve direct child notes including their ID, title, type, MIME type, and modification date.
  * Added tool to move notes to new parent locations with support for handling multiple parent branches.

* **Chores**
  * Version updated to 0.3.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->