### PR TITLE
remove stale .gitignore exception for .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ build/
 .claude/*
 !.claude/rules/
 !.claude/skills/
-!.claude/settings.local.json
 
 .agents/*
 !.agents/rules/


### PR DESCRIPTION
You removed the tracked `.claude/settings.local.json` in 2f08dd74 ("remove agents config files"), but `.gitignore` still contains the `!.claude/settings.local.json` negation that un-ignores it.

`settings.local.json` is Claude Code's per-user local config (personal permission allowlists, hooks, machine-specific paths), so it gets recreated automatically on any machine where someone develops this repo with Claude Code — and with the negation still in place, it shows up as untracked and gets silently re-committed by `git add -A` / `git add .`. That's how the original copy (with a personal Windows path in `additionalDirectories`) ended up in history.

This removes the stale exception so the file stays local. Verified: after this change, a recreated `.claude/settings.local.json` is matched by the `.claude/*` rule (`git check-ignore` confirms) and no longer appears in `git status`. The `!.claude/rules/` and `!.claude/skills/` exceptions are untouched.

Thanks for the server, by the way — I use it daily as the memory backend for my Claude setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules so a local Claude settings file is no longer tracked, while other existing Claude-related exclusions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->